### PR TITLE
Extract the ImageMagick module from govuk-puppet

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,22 @@
+---
+driver:
+  name: docker
+  use_sudo: false
+
+provisioner:
+  name: puppet_apply
+  require_chef_for_busser: false
+  manifests_path: .
+  modules_path: ../
+  custom_pre_apply_command: "mv /tmp/kitchen/modules/puppet-imagemagick /tmp/kitchen/modules/imagemagick"
+
+verifier:
+  name: inspec
+
+platforms:
+  - name: ubuntu-14.04
+
+suites:
+  - name: default
+    provisioner:
+      manifest: site.pp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+---
+language: ruby
+before_install: rm Gemfile.lock || true
+script: bundle exec rake test
+matrix:
+  fast_finish: true
+  include:
+    - rvm: 1.9.3
+      env: PUPPET_VERSION="~> 3.8.0"
+    - rvm: 2.4.0
+      env: PUPPET_VERSION="~> 5.2.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 ---
 language: ruby
 before_install: rm Gemfile.lock || true
+bundler_args: --without functional_tests
 script: bundle exec rake test
 matrix:
   fast_finish: true

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+gem 'puppet', ENV['PUPPET_VERSION'] || '~> 5.2.0'
+
+gem 'rake', '~> 12.1.0'
+gem 'puppet-lint', '~> 2.3.3'
+gem 'rspec-puppet', '~> 2.6.9'
+gem 'puppetlabs_spec_helper', '~> 2.3.2'
+gem 'puppet-syntax', '~> 2.4.1'

--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,10 @@ gem 'puppet-lint', '~> 2.3.3'
 gem 'rspec-puppet', '~> 2.6.9'
 gem 'puppetlabs_spec_helper', '~> 2.3.2'
 gem 'puppet-syntax', '~> 2.4.1'
+
+group :functional_tests do
+  gem 'test-kitchen'
+  gem 'kitchen-docker'
+  gem 'kitchen-inspec'
+  gem 'kitchen-puppet'
+end

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,12 @@
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet-lint/tasks/puppet-lint'
+require 'puppet-syntax/tasks/puppet-syntax'
+
+PuppetLint.configuration.fail_on_warnings = true
+
+desc "Run syntax, lint, and spec tests."
+task :test => [
+  :syntax,
+  :lint,
+  :spec,
+]

--- a/files/etc/ImageMagick/policy.xml
+++ b/files/etc/ImageMagick/policy.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policymap [
+<!ELEMENT policymap (policy)+>
+<!ELEMENT policy (#PCDATA)>
+<!ATTLIST policy domain (delegate|coder|filter|path|resource) #IMPLIED>
+<!ATTLIST policy name CDATA #IMPLIED>
+<!ATTLIST policy rights CDATA #IMPLIED>
+<!ATTLIST policy pattern CDATA #IMPLIED>
+<!ATTLIST policy value CDATA #IMPLIED>
+]>
+<!--
+  Configure ImageMagick policies.
+
+  Domains include system, delegate, coder, filter, path, or resource.
+
+  Rights include none, read, write, and execute.  Use | to combine them,
+  for example: "read | write" to permit read from, or write to, a path.
+
+  Use a glob expression as a pattern.
+
+  Suppose we do not want users to process MPEG video images:
+
+    <policy domain="delegate" rights="none" pattern="mpeg:decode" />
+
+  Here we do not want users reading images from HTTP:
+
+    <policy domain="coder" rights="none" pattern="HTTP" />
+
+  Lets prevent users from executing any image filters:
+
+    <policy domain="filter" rights="none" pattern="*" />
+
+  The /repository file system is restricted to read only.  We use a glob
+  expression to match all paths that start with /repository:
+
+    <policy domain="path" rights="read" pattern="/repository/*" />
+
+  Any large image is cached to disk rather than memory:
+
+    <policy domain="resource" name="area" value="1GB"/>
+
+  Define arguments for the memory, map, area, and disk resources with
+  SI prefixes (.e.g 100MB).  In addition, resource policies are maximums for
+  each instance of ImageMagick (e.g. policy memory limit 1GB, -limit 2GB
+  exceeds policy maximum so memory limit is 1GB).
+-->
+<policymap>
+  <policy domain="coder" rights="none" pattern="EPHEMERAL" />
+  <policy domain="coder" rights="none" pattern="URL" />
+  <policy domain="coder" rights="none" pattern="HTTPS" />
+  <policy domain="coder" rights="none" pattern="MVG" />
+  <policy domain="coder" rights="none" pattern="MSL" />
+  <!-- <policy domain="system" name="precision" value="6"/> -->
+  <!-- <policy domain="resource" name="temporary-path" value="/tmp"/> -->
+  <!-- <policy domain="resource" name="memory" value="2GiB"/> -->
+  <!-- <policy domain="resource" name="map" value="4GiB"/> -->
+  <!-- <policy domain="resource" name="area" value="1GB"/> -->
+  <!-- <policy domain="resource" name="disk" value="16EB"/> -->
+  <!-- <policy domain="resource" name="file" value="768"/> -->
+  <!-- <policy domain="resource" name="thread" value="4"/> -->
+  <!-- <policy domain="resource" name="throttle" value="0"/> -->
+  <!-- <policy domain="resource" name="time" value="3600"/> -->
+</policymap>

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,0 +1,15 @@
+# == Class: imagemagick
+#
+# Installs the imagemagick package.
+#
+class imagemagick {
+  package { 'imagemagick':
+    ensure => 'present',
+  }
+
+  file { '/etc/ImageMagick/policy.xml':
+    ensure  => 'present',
+    content => file('imagemagick/etc/ImageMagick/policy.xml'),
+    require => Package['imagemagick'],
+  }
+}

--- a/site.pp
+++ b/site.pp
@@ -1,0 +1,1 @@
+include imagemagick

--- a/spec/classes/imagemagick_spec.rb
+++ b/spec/classes/imagemagick_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../spec_helper'
+
+describe 'imagemagick', :type => :class do
+
+  it { is_expected.to compile }
+
+  it { is_expected.to compile.with_all_deps }
+
+  it { is_expected.to contain_class('imagemagick') }
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,1 @@
+require 'puppetlabs_spec_helper/module_spec_helper'

--- a/test/integration/default/imagemagick_spec.rb
+++ b/test/integration/default/imagemagick_spec.rb
@@ -1,0 +1,7 @@
+describe package('imagemagick') do
+  it { should be_installed }
+end
+
+describe file('/etc/ImageMagick/policy.xml') do
+  its('content') { should include('<policy domain="coder" rights="none" pattern="HTTPS" />') }
+end


### PR DESCRIPTION
- This is an extraction of the code from https://github.com/alphagov/govuk-puppet/blob/master/modules/imagemagick with the addition of tests, updated Ruby versions and Kitchen CI config.